### PR TITLE
Conditionally install build-essential

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,6 @@ class nodepool (
   }
 
   $packages = [
-    'build-essential',
     'libffi-dev',
     'libssl-dev',
     'libgmp-dev',         # transitive dep of paramiko
@@ -67,6 +66,12 @@ class nodepool (
 
   package { $packages:
     ensure  => present,
+  }
+  
+  if ! defined(Package['build-essential']) {
+    package { 'build-essential':
+      ensure => present,
+    }
   }
 
   file { '/etc/mysql/conf.d/max_connections.cnf':


### PR DESCRIPTION
So that the nodepool and zuul modules can be coinstalled, each needs
a conditional wrapper around the build-essential package to avoid a
duplicate resource conflict.
